### PR TITLE
[GPUPS]fix sparse_ssd_unseenday_threshold

### DIFF
--- a/python/paddle/fluid/incubate/fleet/parameter_server/pslib/node.py
+++ b/python/paddle/fluid/incubate/fleet/parameter_server/pslib/node.py
@@ -446,6 +446,8 @@ class DownpourServer(Server):
             'sparse_delta_keep_days', 16)
         table.accessor.downpour_accessor_param.delete_after_unseen_days = strategy.get(
             'sparse_delete_after_unseen_days', 30)
+        table.accessor.downpour_accessor_param.ssd_unseenday_threshold = strategy.get(
+            'sparse_ssd_unseenday_threshold', 1)
         table.accessor.downpour_accessor_param.show_click_decay_rate = strategy.get(
             'sparse_show_click_decay_rate', 0.98)
         table.accessor.downpour_accessor_param.delete_threshold = strategy.get(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->

修复 ssd_unseenday_thredshold 不生效for dymf