### PR TITLE
[BUG FIX] gpups slot shuffle fix

### DIFF
--- a/paddle/fluid/framework/data_set.cc
+++ b/paddle/fluid/framework/data_set.cc
@@ -1978,7 +1978,9 @@ inline std::default_random_engine& local_random_engine() {
 void SlotRecordDataset::PrepareTrain() {
 #ifdef PADDLE_WITH_GLOO
   if (enable_heterps_) {
-    pre_input_records_.clear();
+    if(slots_shuffle_fea_eval_) {
+        pre_input_records_.clear();
+    }
     if (pre_input_records_.size() == 0 && input_channel_ != nullptr &&
         input_channel_->Size() != 0) {
       // channel shuffle 

--- a/paddle/fluid/framework/data_set.cc
+++ b/paddle/fluid/framework/data_set.cc
@@ -1978,6 +1978,7 @@ inline std::default_random_engine& local_random_engine() {
 void SlotRecordDataset::PrepareTrain() {
 #ifdef PADDLE_WITH_GLOO
   if (enable_heterps_) {
+    pre_input_records_.clear();
     if (pre_input_records_.size() == 0 && input_channel_ != nullptr &&
         input_channel_->Size() != 0) {
       // channel shuffle 

--- a/paddle/fluid/framework/data_set.cc
+++ b/paddle/fluid/framework/data_set.cc
@@ -1659,7 +1659,8 @@ void SlotRecordDataset::GetRandomData(
   // VLOG(0) << "Begin to get_random data";
   for (const auto& rec : slots_shuffle_original_data) {
     SlotRecordCandidate rand_rec;
-    SlotRecord new_rec = rec;
+    SlotRecord new_rec = make_slotrecord();
+    *new_rec = *rec; 
 
     slots_record_shuffle_rclist_.AddAndGet(rec, &rand_rec);
     // VLOG(0) << "shuffle_done";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
fix slots shuffle gpups

- malloc new memory for random_data
- clear pre_input_records_ every time when slots shuffle